### PR TITLE
fixing toNumber overflow + faster toString implementation

### DIFF
--- a/lib/uint32.js
+++ b/lib/uint32.js
@@ -94,7 +94,7 @@
 	 * @return {Number} the converted UINT32
 	 */
 	UINT32.prototype.toNumber = function () {
-		return (this._high << 16) | this._low
+		return (this._high * 65536) + this._low
 	}
 
 	/**
@@ -104,21 +104,7 @@
 	 * @return {String} the converted UINT32
 	 */
 	UINT32.prototype.toString = function (radix) {
-		radix = radix || 10
-		var radixUint = radixCache[radix] || new UINT32(radix)
-
-		if ( !this.gt(radixUint) ) return this.toNumber().toString(radix)
-
-		var self = this.clone()
-		var res = new Array(32)
-		for (var i = 31; i >= 0; i--) {
-			self.div(radixUint)
-			res[i] = self.remainder.toNumber().toString(radix)
-			if ( !self.gt(radixUint) ) break
-		}
-		res[i-1] = self.toNumber().toString(radix)
-
-		return res.join('')
+		return this.toNumber().toString(radix || 10)
 	}
 
 	/**


### PR DESCRIPTION
toNumber() returned invalid (negative) value if it reached 32th bit
because of the nature of Javascripts Number type. Avoiding binary
operations prevents this. Other solution would be using >>>0 (because it
internally converts the number to Uint32,
http://stackoverflow.com/questions/22335853/hack-to-convert-javascript-number-to-uint32)
like this.
((this._high << 16) | this._low) >>> 0
However binary operations are slower (tested in Node 5.x and Chrome 39).
Shifting 16 bits could be replaced by multiplying by 2^16=65536.
After that _high is spaced by 16 bits and _low is not gerater than those
16 bits so logical or could be simply replaced by simple addition.

toString() can leverage this and use native .toString() of JS Number
type for much faster result.
